### PR TITLE
Temporarily comment out the 'prettier' hook from the pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: https://github.com/prettier/prettier
-    rev: "2.0.4"
-    hooks:
-      - id: prettier
-        files: .*\.js$
+  #- repo: https://github.com/prettier/prettier
+  #  rev: "2.1.2"
+  #  hooks:
+  #    - id: prettier
+  #      files: .*\.js$


### PR DESCRIPTION
Disable the `prettier` hook until issues are resolved, so that the GitHub build action doesn't fail.