### PR TITLE
README: fix pointers to logos of contributing organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # The Encryption Compendium
-This repository contains the source code for [The Encryption Compendium](https://encryptioncompendium.org), a project of [Silicon Flatirons](https://siliconflatirons.org) and the [CU Boulder TCP Department](https://www.colorado.edu/program/tcp/).
+This repository contains the source code for [The Encryption Compendium](https://encryptioncompendium.org), a project of [Silicon Flatirons](https://siliconflatirons.org) and the [CU Boulder Law School](https://www.colorado.edu/law/).
 
 **The Encryption Compendium is still under development. We welcome anyone who would like to submit an issue or a pull request to this repository.**
 
 ## Development
 See [DEVELOPMENT.md](/DEVELOPMENT.md) for more information about how to develop the site. If you'd like to open an issue or make a pull request, please refer to [CONTRIBUTING.md](/CONTRIBUTING.md) for contribution guidelines.
 
-![Silicon Flatirons logo](/static/img/silicon_flatirons_logo.gif)
+![Silicon Flatirons logo](/static/img/SILC_logo.png)
 
-![CU Boulder TCP logo](/static/img/tcp_logo.png)
+![CU Boulder Law School logo](/static/img/Colorado_Law_rev_center_gold_law.png)


### PR DESCRIPTION
I note that the the logo for the Colorado Law isn't exactly the TCP
logo, so i'm not sure whether that's the right change.  but it's
better than a broken link anyway.