### PR TITLE
Normalize data.bib to Unicode NFKC

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,4 +35,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install mypy==0.910
       - name: Run type checks
-        run: mypy --strict deploy_tools/generate_compendium.py
+        run: mypy --strict deploy_tools/generate_compendium.py deploy_tools/normalize-unicode.py

--- a/deploy_tools/build_local.sh
+++ b/deploy_tools/build_local.sh
@@ -11,6 +11,8 @@ VENV_DIR="${CURRENT_DIR}/venv"
 wget https://raw.githubusercontent.com/The-Encryption-Compendium/the-encryption-compendium.github.io/main/data/data.bib \
     -O "${CURRENT_DIR}/../data/data.bib"
 
+"${CURRENT_DIR}/normalize-unicode.py" "${CURRENT_DIR}/../data/data.bib"
+
 # Download dependencies
 python3 -m venv "${VENV_DIR}"
 source "${VENV_DIR}/bin/activate"

--- a/deploy_tools/normalize-unicode.py
+++ b/deploy_tools/normalize-unicode.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+from unicodedata import is_normalized, normalize
+from typing import Optional
+from logging import info, basicConfig
+from os import environ, rename
+
+parser = ArgumentParser()
+parser.add_argument("infile", help="BibTeX file containing the site's compendium entries.")
+parser.add_argument("--loglevel", default="info", help="set the log level (default: info)")
+parser.add_argument("--form", default="NFKC", help="choose the preferred Unicode normal form (default: NFKC)")
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    basicConfig(level=args.loglevel.upper())
+    normed:Optional[str] = None
+    with open(args.infile, 'r') as dataf:
+        data = dataf.read()
+        if not is_normalized(args.form, data):
+            normed = normalize(args.form, data)
+    if normed is not None:
+        rename(args.infile, f"{args.infile}.unnormalized")
+        info(f"normalization to {args.form} had an effect, overwriting {args.infile} (backed up to {args.infile}.unnormalized)")
+        with open(args.infile, 'w') as outf:
+            outf.write(normed)


### PR DESCRIPTION
This ensures that weird ligatures like "ﬃ" get converted to
individual, non-combined characters like "ffi".