### PR TITLE
Reduce likelihood of unreproducible entry digests

### DIFF
--- a/deploy_tools/generate_compendium.py
+++ b/deploy_tools/generate_compendium.py
@@ -165,7 +165,9 @@ tags = {self.tags}
         if add_hash:
             # Create a hash of the entire CompendiumEntry and add its first few characters
             # to the slug.
-            data = json.dumps(self.to_json()).encode("utf-8")
+            uid_keys = ("title", "date", "publisher", "authors")
+            uid_dict = {k: v for k, v in self.to_json().items() if k in uid_keys}
+            data = json.dumps(uid_dict, indent=None, sort_keys=True, separators=(',',':')).encode("utf-8")
             h = sha256(data).hexdigest()
             slug += "-" + h[:hash_len]
 


### PR DESCRIPTION
As long as an entry's URL is a digest is generated from the json of an
entry, we should try to ensure that the serialization is as
reproducible as possible.  This change makes it independent of the
default parameters for the most obviously flexible parts of
json.dumps, which might change with revisions of the json module)

see also https://reproducible-builds.org/docs/stable-outputs/

Addresses (but does not completely close) #34