### PR TITLE
Switch the default branch from "master" to "main".

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -66,16 +66,16 @@ jobs:
         run: find public/ -type f
 
       ############################################################################
-      # Deploy the site to GitHub pages. Only triggered by pushes to master.
+      # Deploy the site to GitHub pages. Only triggered by pushes to main.
       ############################################################################
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: The-Encryption-Compendium/the-encryption-compendium.github.io
-          publish_branch: master
+          publish_branch: main
           publish_dir: ./public
           user_name: "github-actions[bot]"
           user_email: "github-actions[bot]@users.noreply.github.com"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ TECv2 is a static site created using [Hugo](https://gohugo.io). The [original ve
 
 ## Build process
 
-This repository primarily contains various scripts, templates, and JS/CSS files. However, to get the site up and running, it must first be built using Hugo. Here is an overview of how the site is built (using [GitHub actions](.github/workflows/ghpages.yml)) whenever a new commit is pushed to `master`:
+This repository primarily contains various scripts, templates, and JS/CSS files. However, to get the site up and running, it must first be built using Hugo. Here is an overview of how the site is built (using [GitHub actions](.github/workflows/ghpages.yml)) whenever a new commit is pushed to `main`:
 
 1. Compendium entries are downloaded from Zotero using the `deploy_tools/scrape_zotero.py` script and an API key for the research team's Zotero. There are stored in a BibTeX file, `data/data.bib`.
 2. The BibTeX file is converted into JSON and stored in a JavaScript file, `assets/js/entries.js`. In addition, Markdown files are generated for every entry and stored in `content/entries/`. This process is controlled by `deploy_tools/generate_compendium.py`.

--- a/deploy_tools/build_local.sh
+++ b/deploy_tools/build_local.sh
@@ -8,7 +8,7 @@ CURRENT_DIR=$(dirname "$0")
 VENV_DIR="${CURRENT_DIR}/venv"
 
 # Download compendium entries locally
-wget https://raw.githubusercontent.com/The-Encryption-Compendium/the-encryption-compendium.github.io/master/data/data.bib \
+wget https://raw.githubusercontent.com/The-Encryption-Compendium/the-encryption-compendium.github.io/main/data/data.bib \
     -O "${CURRENT_DIR}/../data/data.bib"
 
 # Download dependencies


### PR DESCRIPTION
Modify the GitHub Actions workflow so that it only runs the staging site
deployment step on pushes to main, rather than pushes to master. This
also updates DEVELOPMENT.md to refer to "main" rather than "master", and
the build_local.sh script to fetch data.bib from the "main" branch of
the GitHub Pages repo.

Closes #41.