### PR TITLE
Fix type errors in generate_compendium.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8]
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-build-${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mypy==0.910
+      - name: Run type checks
+        run: mypy --strict deploy_tools/generate_compendium.py


### PR DESCRIPTION
This PR fixes type errors in the `generate_compendium.py` script, and fixes a couple of minor bugs in the script along the way.  In addition, it adds a new GitHub Action that runs `mypy --strict generate_compendium.py` on pull requests and pushes to `main`. If/when we add more scripts to the repository, we may want to run mypy against those scripts as well.

Closes #33.