### PR TITLE
Fix duplicate key in the test workflow.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,6 @@ jobs:
   test:
     name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This fixes a small error in the GitHub Actions workflow for running
tests; tests should run on pushes to main after this fix.
*crosses fingers*