### PR TITLE
Check bibtex for duplicate indexes

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Download compendium entries
         run: python -m deploy_tools.scrape_zotero "${{ secrets.API_KEY }}"
+      - name: Verify bibtex
+        run: |
+          deploy_tools/bibtex_verify.py data/data.bib
 
       - name: Build
         run: |

--- a/deploy_tools/bibtex_verify.py
+++ b/deploy_tools/bibtex_verify.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+'''
+Verify bibtex
+'''
+
+from argparse import ArgumentParser
+from logging import basicConfig
+from typing import Dict, Optional, List, Any
+import sys
+
+from bibtexparser.bparser import BibTexParser, BibDatabase # type: ignore
+
+parser = ArgumentParser()
+parser.add_argument("infile", help="BibTeX file containing the site's compendium entries.")
+parser.add_argument("--loglevel", default="info", help="set the log level (default: info)")
+
+def get_entry_id(bib_entry: Dict[str, Any]) -> str:
+    'get the string ID from a bibtex entry'
+    if 'ID' not in bib_entry:
+        raise KeyError('entry has no ID field')
+    ret = bib_entry['ID']
+    if not isinstance(ret, str):
+        raise TypeError(f'ID is {type(ret)}')
+    return ret
+
+def check_for_duplicate_ids(bib_db: BibDatabase) -> Optional[str]:
+    'return an error string if there are any duplicate IDs'
+    ids:List[str] = list(map(get_entry_id, bib_db.entries))
+    dups = set()
+    for name in ids:
+        if ids.count(name) > 1:
+            dups.add(name)
+    if dups:
+        return f"duplicate IDs: {dups}"
+    return None
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    basicConfig(level=args.loglevel.upper())
+    bibtex = BibTexParser(common_strings=True)
+    bibdb:BibDatabase
+    with open(args.infile, 'r') as dataf:
+        bibdb = bibtex.parse_file(dataf)
+
+    duperr = check_for_duplicate_ids(bibdb)
+    if duperr is not None:
+        print(duperr, file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
This is a simple test -- any duplicate bibtex ID will cause all but
one of the entries to be skipped in entries_dict due to the collision.

The goal is to abort the site build if `data.bib` has such a duplicate
entry.

This is still pretty weak: it doesn't test whether `data.bib` is valid
bibtex, it doesn't verify anything else about the entries, but it also
offers a place to do more in-depth consistency/cleanliness checks on
the data scraped from zotero.

Addresses (but does not close) #46.